### PR TITLE
avoid possible null-ptr-deref

### DIFF
--- a/libsegfault.c
+++ b/libsegfault.c
@@ -1,6 +1,11 @@
-#include <stddef.h>
 #include "segfault.h"
+#include <stddef.h>
+#include <stdio.h>
 
 int sigsegv(void) {
-    return *(volatile int *) NULL;
+  if (!*(volatile int *)NULL) {
+    fprintf(stderr, "AVOID POSSIBLE NULL PTR DEREFERENCE!\n");
+    return 1;
+  }
+  return *(volatile int *)NULL;
 }


### PR DESCRIPTION
Add check if the value is NULL to avoid possible NULL pointer dereference.

This bug is assigned a CVE.